### PR TITLE
feat: add queue_id support to LoungeStatus events

### DIFF
--- a/examples/advanced_usage.rs
+++ b/examples/advanced_usage.rs
@@ -266,7 +266,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             println!("  Playlist: {}", list_id);
                         }
                     }
-                    LoungeEvent::LoungeStatus(devices) => {
+                    LoungeEvent::LoungeStatus(devices, queue_id) => {
                         println!("Lounge status update - Connected devices:");
                         for device in devices {
                             println!("  Device: {} ({})", device.name, device.device_type);
@@ -276,6 +276,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     info.brand, info.model, info.device_type
                                 );
                             }
+                        }
+
+                        // Display the queue ID if available
+                        if let Some(id) = queue_id {
+                            println!("  Queue ID: {}", id);
                         }
                     }
                     LoungeEvent::ScreenDisconnected => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -873,7 +873,10 @@ async fn process_event_chunk(
                                     })
                                     .collect();
 
-                                let _ = sender.send(LoungeEvent::LoungeStatus(devices_with_info));
+                                let _ = sender.send(LoungeEvent::LoungeStatus(
+                                    devices_with_info,
+                                    status.queue_id.clone(),
+                                ));
                             }
                         }
                     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,7 +9,7 @@ use crate::models::{
 pub enum LoungeEvent {
     StateChange(PlaybackState),
     NowPlaying(NowPlaying),
-    LoungeStatus(Vec<Device>),
+    LoungeStatus(Vec<Device>, Option<String>), // Add queue_id parameter
     ScreenDisconnected,
     SessionEstablished,
     AdStateChange(AdState),
@@ -30,7 +30,7 @@ impl LoungeEvent {
         match self {
             LoungeEvent::StateChange(_) => "onStateChange",
             LoungeEvent::NowPlaying(_) => "nowPlaying",
-            LoungeEvent::LoungeStatus(_) => "loungeStatus",
+            LoungeEvent::LoungeStatus(_, _) => "loungeStatus",
             LoungeEvent::ScreenDisconnected => "loungeScreenDisconnected",
             LoungeEvent::SessionEstablished => "sessionEstablished",
             LoungeEvent::AdStateChange(_) => "onAdStateChange",

--- a/src/models.rs
+++ b/src/models.rs
@@ -160,6 +160,8 @@ pub struct Device {
 #[derive(Debug, Clone, Deserialize)]
 pub struct LoungeStatus {
     pub devices: String,
+    #[serde(rename = "queueId", default)]
+    pub queue_id: Option<String>,
 }
 
 // Ad state change event

--- a/tests/events_tests.rs
+++ b/tests/events_tests.rs
@@ -1,6 +1,7 @@
 use youtube_lounge_rs::models::{
     AdState, AudioTrackChanged, AutoplayModeChanged, AutoplayUpNext, HasPreviousNextChanged,
-    PlaylistModified, SubtitlesTrackChanged, VideoData, VideoQualityChanged, VolumeChanged,
+    LoungeStatus, PlaylistModified, SubtitlesTrackChanged, VideoData, VideoQualityChanged,
+    VolumeChanged,
 };
 use youtube_lounge_rs::{Device, LoungeEvent, NowPlaying, PlaybackState};
 
@@ -61,7 +62,7 @@ fn test_lounge_event_variants() {
         },
     ];
 
-    let _event = LoungeEvent::LoungeStatus(devices);
+    let _event = LoungeEvent::LoungeStatus(devices, Some("RQ1234".to_string()));
 
     // Test ScreenDisconnected
     let _event = LoungeEvent::ScreenDisconnected;
@@ -174,7 +175,7 @@ fn test_lounge_event_matching() {
             state: 0,
             video_data,
         }),
-        LoungeEvent::LoungeStatus(vec![]),
+        LoungeEvent::LoungeStatus(vec![], None),
         LoungeEvent::ScreenDisconnected,
         LoungeEvent::Unknown("".to_string()),
         LoungeEvent::AdStateChange(AdState {
@@ -221,7 +222,7 @@ fn test_lounge_event_matching() {
             LoungeEvent::SessionEstablished => {}
             LoungeEvent::StateChange(_) => {}
             LoungeEvent::NowPlaying(_) => {}
-            LoungeEvent::LoungeStatus(_) => {}
+            LoungeEvent::LoungeStatus(_, _) => {}
             LoungeEvent::ScreenDisconnected => {}
             LoungeEvent::Unknown(_) => {}
             LoungeEvent::AdStateChange(_) => {}
@@ -265,6 +266,25 @@ fn test_volume_utility_methods() {
 
     assert_eq!(volume_invalid.volume_level(), 0);
     assert!(!volume_invalid.is_muted());
+}
+
+#[test]
+fn test_lounge_status_queue_id() {
+    // Test LoungeStatus with queue_id
+    let status_with_queue = LoungeStatus {
+        devices: "[]".to_string(),
+        queue_id: Some("RQ1234567890".to_string()),
+    };
+
+    assert_eq!(status_with_queue.queue_id, Some("RQ1234567890".to_string()));
+
+    // Test LoungeStatus without queue_id
+    let status_without_queue = LoungeStatus {
+        devices: "[]".to_string(),
+        queue_id: None,
+    };
+
+    assert_eq!(status_without_queue.queue_id, None);
 }
 
 #[test]


### PR DESCRIPTION
## Description
Add missing queue_id to LoungeStatus event

## Related Issue
None

## Motivation and Context
Should have been done like this in the first place.

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- [x] Added unit tests
- [x] Tested manually with a real YouTube device
- [ ] Other (please describe):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactoring

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **CONTRIBUTING.md** document (if available)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My change is backward compatible with previous versions (if not, explain why)