### PR TITLE
feat: implement addVideo command and improve API clarity

### DIFF
--- a/examples/advanced_usage.rs
+++ b/examples/advanced_usage.rs
@@ -426,9 +426,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Play a specific video with automatic token refresh
     match client
-        .send_command_with_refresh(PlaybackCommand::SetPlaylist {
-            video_id: video_id.to_string(),
-        })
+        .send_command_with_refresh(PlaybackCommand::set_playlist(video_id.to_string()))
         .await
     {
         Ok(_) => println!("Started playback of video: {}", video_id),
@@ -503,6 +501,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         Ok(_) => println!("Audio unmuted"),
         Err(e) => eprintln!("Failed to unmute: {}", e),
+    }
+
+    sleep(Duration::from_secs(2)).await;
+
+    // Demonstrate the AddVideo command - add another video to the queue
+    println!("\nDemonstrating queue functionality...");
+    println!("Adding a video to the queue (will play after current video)");
+    // Use a different video for demonstration
+    let queue_video_id = "QH2-TGUlwu4"; // Nyan Cat
+    match client
+        .send_command_with_refresh(PlaybackCommand::add_video(queue_video_id.to_string()))
+        .await
+    {
+        Ok(_) => println!("Successfully added video {} to queue", queue_video_id),
+        Err(e) => eprintln!("Failed to add video to queue: {}", e),
     }
 
     // Keeping the connection alive for a while - wait a bit longer

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -104,9 +104,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Play a specific video
     println!("Starting a video...");
     client
-        .send_command_with_refresh(PlaybackCommand::SetPlaylist {
-            video_id: "dQw4w9WgXcQ".to_string(), // Rick Astley - Never Gonna Give You Up
-        })
+        .send_command_with_refresh(
+            PlaybackCommand::set_playlist("dQw4w9WgXcQ".to_string()), // Rick Astley
+        )
         .await?;
 
     // Wait for the video to start

--- a/src/client.rs
+++ b/src/client.rs
@@ -740,8 +740,80 @@ impl LoungeClient {
 
         // Add command-specific parameters efficiently
         match &command {
-            PlaybackCommand::SetPlaylist { video_id } => {
+            PlaybackCommand::SetPlaylist {
+                video_id,
+                current_index,
+                list_id,
+                current_time,
+                audio_only,
+                params,
+                player_params,
+            } => {
+                // Required parameter
                 form_data.push_str(&format!("&req0_videoId={}", video_id));
+
+                // Optional parameters - only add if Some
+                if let Some(idx) = current_index {
+                    form_data.push_str(&format!("&req0_currentIndex={}", idx));
+                } else {
+                    // Default to -1 as per the Lounge API documentation
+                    form_data.push_str("&req0_currentIndex=-1");
+                }
+
+                // Add list_id if provided
+                if let Some(list) = list_id {
+                    form_data.push_str(&format!("&req0_listId={}", list));
+                } else {
+                    // Empty listId as per documentation
+                    form_data.push_str("&req0_listId=");
+                }
+
+                // Add current_time if provided
+                if let Some(time) = current_time {
+                    form_data.push_str(&format!("&req0_currentTime={}", time));
+                } else {
+                    // Default to 0 as per documentation
+                    form_data.push_str("&req0_currentTime=0");
+                }
+
+                // Add audio_only if provided
+                if let Some(audio) = audio_only {
+                    form_data.push_str(&format!("&req0_audioOnly={}", audio));
+                } else {
+                    // Default to false as per documentation
+                    form_data.push_str("&req0_audioOnly=false");
+                }
+
+                // Add params if provided
+                if let Some(p) = params {
+                    form_data.push_str(&format!("&req0_params={}", p));
+                } else {
+                    // Empty params as per documentation
+                    form_data.push_str("&req0_params=");
+                }
+
+                // Add player_params if provided
+                if let Some(pp) = player_params {
+                    form_data.push_str(&format!("&req0_playerParams={}", pp));
+                } else {
+                    // Empty playerParams as per documentation
+                    form_data.push_str("&req0_playerParams=");
+                }
+
+                // Add recommended param from documentation
+                form_data.push_str("&req0_prioritizeMobileSenderPlaybackStateOnConnection=true");
+            }
+            PlaybackCommand::AddVideo {
+                video_id,
+                video_sources,
+            } => {
+                // Required parameter
+                form_data.push_str(&format!("&req0_videoId={}", video_id));
+
+                // Optional parameter
+                if let Some(sources) = video_sources {
+                    form_data.push_str(&format!("&req0_videoSources={}", sources));
+                }
             }
             PlaybackCommand::SeekTo { new_time } => {
                 form_data.push_str(&format!("&req0_newTime={}", new_time));
@@ -856,7 +928,8 @@ impl LoungeClient {
             ("app", "web"),
             ("mdx-version", "3"),
             ("name", &encoded_name),
-            ("id", &self.screen_id),
+            // Per API docs, id should be empty for initial connection, not the screen_id
+            ("id", ""),
             ("device", "REMOTE_CONTROL"),
             ("capabilities", "que,dsdtr,atp"),
             ("method", "setPlaylist"),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,10 +6,44 @@ pub enum PlaybackCommand {
     Next,
     Previous,
     SkipAd,
-    SetPlaylist { video_id: String },
-    SeekTo { new_time: f64 },
-    SetAutoplayMode { autoplay_mode: String },
-    SetVolume { volume: i32 },
+    /// Set and play a video, replacing current playlist
+    ///
+    /// This command starts playback of a new video, replacing the current playlist.
+    SetPlaylist {
+        video_id: String,
+        // Optional parameters with defaults
+        #[doc(hidden)]
+        current_index: Option<i32>,
+        #[doc(hidden)]
+        list_id: Option<String>,
+        #[doc(hidden)]
+        current_time: Option<f64>,
+        #[doc(hidden)]
+        audio_only: Option<bool>,
+        #[doc(hidden)]
+        params: Option<String>,
+        #[doc(hidden)]
+        player_params: Option<String>,
+    },
+    /// Add a video to the queue without interrupting current playback
+    ///
+    /// This command adds a video to the end of the current playlist
+    /// without interrupting the currently playing video.
+    AddVideo {
+        video_id: String,
+        // Optional parameter
+        #[doc(hidden)]
+        video_sources: Option<String>,
+    },
+    SeekTo {
+        new_time: f64,
+    },
+    SetAutoplayMode {
+        autoplay_mode: String,
+    },
+    SetVolume {
+        volume: i32,
+    },
     Mute,
     Unmute,
 }
@@ -23,10 +57,37 @@ pub fn get_command_name(command: &PlaybackCommand) -> String {
         PlaybackCommand::Previous => "previous".to_string(),
         PlaybackCommand::SkipAd => "skipAd".to_string(),
         PlaybackCommand::SetPlaylist { .. } => "setPlaylist".to_string(),
+        PlaybackCommand::AddVideo { .. } => "addVideo".to_string(),
         PlaybackCommand::SeekTo { .. } => "seekTo".to_string(),
         PlaybackCommand::SetAutoplayMode { .. } => "setAutoplayMode".to_string(),
         PlaybackCommand::SetVolume { .. } => "setVolume".to_string(),
         PlaybackCommand::Mute => "mute".to_string(),
         PlaybackCommand::Unmute => "unMute".to_string(),
+    }
+}
+
+// Implementation block for direct command construction
+impl PlaybackCommand {
+    /// Create SetPlaylist command from just a video_id
+    ///
+    /// All optional parameters will have sensible defaults.
+    pub fn set_playlist(video_id: String) -> Self {
+        PlaybackCommand::SetPlaylist {
+            video_id,
+            current_index: Some(-1),
+            list_id: None,
+            current_time: Some(0.0),
+            audio_only: Some(false),
+            params: None,
+            player_params: None,
+        }
+    }
+
+    /// Create AddVideo command from just a video_id
+    pub fn add_video(video_id: String) -> Self {
+        PlaybackCommand::AddVideo {
+            video_id,
+            video_sources: None,
+        }
     }
 }

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -38,9 +38,22 @@ async fn test_command_names() {
     // Test commands with parameters
     assert_eq!(
         get_command_name(&PlaybackCommand::SetPlaylist {
-            video_id: "dQw4w9WgXcQ".to_string()
+            video_id: "dQw4w9WgXcQ".to_string(),
+            current_index: Some(-1),
+            list_id: None,
+            current_time: Some(0.0),
+            audio_only: Some(false),
+            params: None,
+            player_params: None,
         }),
         "setPlaylist"
+    );
+    assert_eq!(
+        get_command_name(&PlaybackCommand::AddVideo {
+            video_id: "dQw4w9WgXcQ".to_string(),
+            video_sources: None,
+        }),
+        "addVideo"
     );
     assert_eq!(
         get_command_name(&PlaybackCommand::SeekTo { new_time: 42.0 }),
@@ -101,6 +114,51 @@ async fn test_event_receiver() {
             }
         }
         Err(_) => panic!("Did not receive event"),
+    }
+}
+
+// Test helper constructor methods for commands
+#[tokio::test]
+async fn test_command_constructors() {
+    use youtube_lounge_rs::PlaybackCommand;
+
+    // Test the set_playlist helper
+    let video_id = "dQw4w9WgXcQ".to_string();
+    let set_playlist = PlaybackCommand::set_playlist(video_id.clone());
+
+    match set_playlist {
+        PlaybackCommand::SetPlaylist {
+            video_id: vid,
+            current_index,
+            list_id,
+            current_time,
+            audio_only,
+            params,
+            player_params,
+        } => {
+            assert_eq!(vid, video_id);
+            assert_eq!(current_index, Some(-1));
+            assert_eq!(list_id, None);
+            assert_eq!(current_time, Some(0.0));
+            assert_eq!(audio_only, Some(false));
+            assert_eq!(params, None);
+            assert_eq!(player_params, None);
+        }
+        _ => panic!("Wrong command type returned by set_playlist"),
+    }
+
+    // Test the add_video helper
+    let add_video = PlaybackCommand::add_video(video_id.clone());
+
+    match add_video {
+        PlaybackCommand::AddVideo {
+            video_id: vid,
+            video_sources,
+        } => {
+            assert_eq!(vid, video_id);
+            assert_eq!(video_sources, None);
+        }
+        _ => panic!("Wrong command type returned by add_video"),
     }
 }
 


### PR DESCRIPTION
## Description
- Add AddVideo command for queuing videos to playlist
- Simplify command API with static methods instead of constructors
- Fix bug in connection form data where 'id' was incorrectly set
- Add complete optional parameters to SetPlaylist per API docs
- Update examples and tests to use new API style

## Related Issue
None

## Motivation and Context
A command was missing.

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- [x] Added unit tests
- [ ] Tested manually with a real YouTube device
- [ ] Other (please describe):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code cleanup or refactoring

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **CONTRIBUTING.md** document (if available)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] My change is backward compatible with previous versions (if not, explain why)