### PR TITLE
feat: add playlist playback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,27 @@ while let Some(event) = rx.recv().await {
 ### Controlling playback
 
 ```rust
-// Play a specific video
+// Play a specific video (recommended method)
+client.send_command(PlaybackCommand::set_playlist("dQw4w9WgXcQ".to_string())).await?;
+
+// Play a YouTube playlist by ID
+client.send_command(PlaybackCommand::set_playlist_by_id("PLxxxx".to_string())).await?;
+
+// Play a specific video in a playlist by index
+client.send_command(PlaybackCommand::set_playlist_with_index("PLxxxx".to_string(), 3)).await?;
+
+// Add a video to the queue (will play after current video)
+client.send_command(PlaybackCommand::add_video("QH2-TGUlwu4".to_string())).await?;
+
+// Manual construction (advanced usage with all parameters)
 client.send_command(PlaybackCommand::SetPlaylist { 
-    video_id: "dQw4w9WgXcQ".to_string() 
+    video_id: "dQw4w9WgXcQ".to_string(),
+    current_index: Some(-1),
+    list_id: None,
+    current_time: Some(0.0),
+    audio_only: Some(false),
+    params: None,
+    player_params: None,
 }).await?;
 
 // Pause playback
@@ -274,15 +292,51 @@ When debug mode is enabled, all events (including unknown ones) will print their
 
 Commands that can be sent to control playback:
 
-- `Play`
-- `Pause`
-- `Next`
-- `Previous`
-- `SkipAd`
-- `SetPlaylist { video_id: String }`
-- `SeekTo { new_time: f64 }`
-- `SetAutoplayMode { autoplay_mode: String }`
-- `SetVolume { volume: i32 }`
+#### Basic Control Commands
+- `Play` - Resume playback
+- `Pause` - Pause playback
+- `Next` - Skip to next video
+- `Previous` - Go to previous video
+- `SkipAd` - Skip current advertisement
+- `SeekTo { new_time: f64 }` - Seek to specific position
+- `SetAutoplayMode { autoplay_mode: String }` - Change autoplay settings
+- `SetVolume { volume: i32 }` - Set volume level (0-100)
+- `Mute` - Mute audio
+- `Unmute` - Unmute audio
+
+#### Content Commands
+
+**Play a single video:**
+```rust
+// Recommended approach
+PlaybackCommand::set_playlist("dQw4w9WgXcQ".to_string())
+
+// Full manual construction
+PlaybackCommand::SetPlaylist { 
+    video_id: "dQw4w9WgXcQ".to_string(),
+    current_index: Some(-1),
+    list_id: None,
+    current_time: Some(0.0),
+    audio_only: Some(false),
+    params: None,
+    player_params: None,
+}
+```
+
+**Play a YouTube playlist:**
+```rust
+// Play from beginning of playlist
+PlaybackCommand::set_playlist_by_id("PLxxxx".to_string())
+
+// Play specific video in playlist by index
+PlaybackCommand::set_playlist_with_index("PLxxxx".to_string(), 3)
+```
+
+**Add a video to queue:**
+```rust
+// Add to end of current queue
+PlaybackCommand::add_video("QH2-TGUlwu4".to_string())
+```
 
 ### `LoungeEvent`
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -749,7 +749,7 @@ impl LoungeClient {
                 params,
                 player_params,
             } => {
-                // Required parameter
+                // Add video_id (may be empty if using list_id)
                 form_data.push_str(&format!("&req0_videoId={}", video_id));
 
                 // Optional parameters - only add if Some
@@ -807,7 +807,7 @@ impl LoungeClient {
                 video_id,
                 video_sources,
             } => {
-                // Required parameter
+                // Required parameter for AddVideo
                 form_data.push_str(&format!("&req0_videoId={}", video_id));
 
                 // Optional parameter

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,14 +6,17 @@ pub enum PlaybackCommand {
     Next,
     Previous,
     SkipAd,
-    /// Set and play a video, replacing current playlist
+    /// Set and play a video or playlist, replacing current content
     ///
-    /// This command starts playback of a new video, replacing the current playlist.
+    /// This command starts playback of a new video or playlist, replacing the current content.
+    /// At least one of video_id or list_id must have a value.
     SetPlaylist {
+        /// ID of the video to play (can be empty if list_id is provided)
         video_id: String,
         // Optional parameters with defaults
         #[doc(hidden)]
         current_index: Option<i32>,
+        /// ID of the playlist to play (optional, but required if video_id is empty)
         #[doc(hidden)]
         list_id: Option<String>,
         #[doc(hidden)]
@@ -70,6 +73,7 @@ pub fn get_command_name(command: &PlaybackCommand) -> String {
 impl PlaybackCommand {
     /// Create SetPlaylist command from just a video_id
     ///
+    /// This plays a specific video by its ID, replacing any current content.
     /// All optional parameters will have sensible defaults.
     pub fn set_playlist(video_id: String) -> Self {
         PlaybackCommand::SetPlaylist {
@@ -83,7 +87,41 @@ impl PlaybackCommand {
         }
     }
 
+    /// Create SetPlaylist command to play a playlist by its ID
+    ///
+    /// This plays a specific playlist, starting from the first video.
+    /// All optional parameters will have sensible defaults.
+    pub fn set_playlist_by_id(list_id: String) -> Self {
+        PlaybackCommand::SetPlaylist {
+            video_id: "".to_string(), // Empty when playing by playlist ID
+            current_index: Some(0),   // Start from the beginning of playlist
+            list_id: Some(list_id),
+            current_time: Some(0.0),
+            audio_only: Some(false),
+            params: None,
+            player_params: None,
+        }
+    }
+
+    /// Create SetPlaylist command to play a specific video in a playlist
+    ///
+    /// This plays a specific video by its index in a playlist.
+    /// All optional parameters will have sensible defaults.
+    pub fn set_playlist_with_index(list_id: String, index: i32) -> Self {
+        PlaybackCommand::SetPlaylist {
+            video_id: "".to_string(), // Empty when playing by playlist ID
+            current_index: Some(index),
+            list_id: Some(list_id),
+            current_time: Some(0.0),
+            audio_only: Some(false),
+            params: None,
+            player_params: None,
+        }
+    }
+
     /// Create AddVideo command from just a video_id
+    ///
+    /// This adds a video to the end of the current queue without interrupting playback.
     pub fn add_video(video_id: String) -> Self {
         PlaybackCommand::AddVideo {
             video_id,

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -147,6 +147,57 @@ async fn test_command_constructors() {
         _ => panic!("Wrong command type returned by set_playlist"),
     }
 
+    // Test the set_playlist_by_id helper
+    let playlist_id = "PLxxx123456".to_string();
+    let play_playlist = PlaybackCommand::set_playlist_by_id(playlist_id.clone());
+
+    match play_playlist {
+        PlaybackCommand::SetPlaylist {
+            video_id,
+            current_index,
+            list_id,
+            current_time,
+            audio_only,
+            params,
+            player_params,
+        } => {
+            assert_eq!(video_id, ""); // Should be empty when playing by playlist ID
+            assert_eq!(current_index, Some(0)); // Start from beginning
+            assert_eq!(list_id, Some(playlist_id.clone()));
+            assert_eq!(current_time, Some(0.0));
+            assert_eq!(audio_only, Some(false));
+            assert_eq!(params, None);
+            assert_eq!(player_params, None);
+        }
+        _ => panic!("Wrong command type returned by set_playlist_by_id"),
+    }
+
+    // Test the set_playlist_with_index helper
+    let index = 3;
+    let play_playlist_at_index =
+        PlaybackCommand::set_playlist_with_index(playlist_id.clone(), index);
+
+    match play_playlist_at_index {
+        PlaybackCommand::SetPlaylist {
+            video_id,
+            current_index,
+            list_id,
+            current_time,
+            audio_only,
+            params,
+            player_params,
+        } => {
+            assert_eq!(video_id, ""); // Should be empty when playing by playlist ID
+            assert_eq!(current_index, Some(index)); // Start from specified index
+            assert_eq!(list_id, Some(playlist_id));
+            assert_eq!(current_time, Some(0.0));
+            assert_eq!(audio_only, Some(false));
+            assert_eq!(params, None);
+            assert_eq!(player_params, None);
+        }
+        _ => panic!("Wrong command type returned by set_playlist_with_index"),
+    }
+
     // Test the add_video helper
     let add_video = PlaybackCommand::add_video(video_id.clone());
 


### PR DESCRIPTION
## Description

- Enhance SetPlaylist command to support playing playlists by ID
- Add set_playlist_by_id() and set_playlist_with_index() helper methods
- Update documentation and tests for playlist functionality
- Improve README with examples for all playback methods
- Fix implementation to handle empty video_id for playlist playback

## Related Issue
None

## Motivation and Context
Fix documentation and add some helper methods

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- [x] Added unit tests
- [ ] Tested manually with a real YouTube device
- [ ] Other (please describe):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactoring

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **CONTRIBUTING.md** document (if available)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] My change is backward compatible with previous versions (if not, explain why)

Commands have change slightly, not backwards compatible