### PR TITLE
chore: Update release to remove GITHUB_TOKEN added by mistake

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,3 @@ jobs:
       cargo-registry-token: ${{ secrets.CRATES_IO_TOKEN }}
       # Optional, but must be specified with github_app_id input is set
       # github_app_private_key: ${{ secrets.SEMANTIC_RELEASE_GITHUB_PRIVATE_KEY }}
-      github-token: ${{ secrets.GITHUB_TOKEN }} # Ensure this is passed if the reusable workflow needs it


### PR DESCRIPTION
# Description
We don't need to pass a reference to GITHUB_TOKEN here

## Related Issue


## Motivation and Context
Fix a previous mistake

## How Has This Been Tested?
It has not been, it needs to run on Github Action