### PR TITLE
Add DuplicateScreen error.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,9 @@ pub enum LoungeError {
 
     #[error("Task panicked or cancelled")]
     TaskJoinError(#[from] tokio::task::JoinError),
+
+    #[error("Already connected to screen: {0}")]
+    DuplicateScreen(String),
 }
 
 impl LoungeError {


### PR DESCRIPTION
# Description
Add DuplicateScreen error so we have something to throw if we are asked to connect to the same screen twice.